### PR TITLE
Expose bluebird promises…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-var httpinvoke = require('httpinvoke'),
+var rp = require('request-promise'),
     debug = require('debug')('node-onlinelabs:lib'),
     config = require('./config'),
     _ = require('lodash');
@@ -12,44 +12,16 @@ var Client = module.exports = function(options) {
 (function() {
   var client;
 
-  // hooks
-  var hook_finished = function(err, output, statusCode, headers) {
-    // error handling
-    var err_ret;
-    if(err) {
-      return arguments;
-    }
-    if(typeof statusCode === 'undefined') {
-      err_ret = new Error('Server or client error - undefined HTTP status');
-      err_ret.output = output;
-      err_ret.statusCode = statusCode;
-      err_ret.headers = headers;
-      return [err_ret , output, statusCode, headers];
-    }
-    if(statusCode >= 400 && statusCode <= 599) {
-      err_ret = new Error(output.message + ' - ' + output.type + '(' + statusCode + ')');
-      err_ret.output = output;
-      err_ret.statusCode = statusCode;
-      err_ret.headers = headers;
-      return [err_ret, output, statusCode, headers];
-    }
-
-    return arguments;
-  };
-  this.httpinvoke = httpinvoke.hook('finished', hook_finished);
-
   this.request = function(path, method, options, cb) {
     client = this;
     var url = client.config.api_endpoint + path.replace(/^\//, '');
     options = options || {};
     _.defaults(options, {
-      partialOutputMode: 'joined',
-      converters: {
-        'text json': JSON.parse,
-        'json text': JSON.stringify
-      },
+      method: method,
+      url: url,
       headers: {},
-      outputType: 'json'
+      json: true,
+      resolveWithFullResponse: true
     });
     _.defaults(options.headers, {
       'Accept': 'application/json',
@@ -62,7 +34,7 @@ var Client = module.exports = function(options) {
     }
 
     debug(method + ' ' + url, options);
-    return this.httpinvoke(url, method, options, cb);
+    return rp(options).promise().nodeify(cb);
   };
 
   this.get = function(path, options, cb) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "chai": "^2.1.2",
     "debug": "^2.1.3",
-    "httpinvoke": "^1.4.0",
+    "request-promise": "^0.4.1",
     "lodash": "^3.5.0",
     "rc": "^1.0.0"
   },

--- a/test/all.js
+++ b/test/all.js
@@ -48,41 +48,37 @@ suite("[client]", function() {
   suite("#get", function() {
     test("should successfully execute GET /", function(done) {
       this.timeout(5000);
-      client.get("/").then(
-        function(res) {
-          inspect('res', res);
-          try {
-            (res.statusCode).should.equal(200);
-            (res.headers['content-type']).should.equal('application/json');
-            (res.body.api).should.equal('api-compute');
-            done();
-          } catch (e) {
-            done(e);
-          }
-        },
-        function(err) {
-          inspect('err', err);
-          done(err);
-        });
+      client.get("/").then(function(res) {
+        inspect('res', res);
+        try {
+          (res.statusCode).should.equal(200);
+          (res.headers['content-type']).should.equal('application/json');
+          (res.body.api).should.equal('api-compute');
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }).catch(function(err) {
+        inspect('err', err);
+        done(err);
+      });
     });
 
     test("should raise an authentication error", function(done) {
-      client.get("/servers").then(
-        function(res) {
-          inspect('res', res);
-          done(res);
-        },
-        function(err) {
-          inspect('err', err);
-          try {
-            (err.statusCode).should.equal(401);
-            (err.headers['content-type']).should.equal('application/json');
-            (err.output.type).should.equal('invalid_auth');
-            done();
-          } catch (e) {
-            done(e);
-          }
-        });
+      client.get("/servers").then(function(res) {
+        inspect('res', res);
+        done(res);
+      }).catch(function(err) {
+        inspect('err', err);
+        try {
+          (err.statusCode).should.equal(401);
+          (err.response.headers['content-type']).should.equal('application/json');
+          (err.error.type).should.equal('invalid_auth');
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
… instead of httpinvoke’s homemade wrapper.

Feel free to merge, or not.
But https://github.com/request/request response objects are more common, so are Bluebird promises.

I removed the hook as I’m not sure that it does anything.
